### PR TITLE
Fix expression to retrieve token

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ app.use(upload.none())
 app.use(bodyParser.json())
 
 app.post('/message', upload.none(), bodyParser.json(), async (req, res) => {
-  const token = req.query.token || req.headers['x-gotify-key'] || req.headers.authorization ? req.headers.authorization.replace('Bearer ', '') : ''
+  const token = req.query.token || req.headers['x-gotify-key'] || (req.headers.authorization ? req.headers.authorization.replace('Bearer ', '') : '')
 
   mainStory.debug('MESSAGE', 'Gotify message recieved:', {
     attach: { ...req.body, token },


### PR DESCRIPTION
When running the server using docker or yarn start, I encounter this error when the Authorization header is not set (using the query parameter instead)

```
TypeError: undefined is not an object (evaluating 'req.headers.authorization.replace')
      at <anonymous> (/home/repos/gotify-to-ntfy-proxy/index.js:42:107)
      at <anonymous> (/home/repos/gotify-to-ntfy-proxy/index.js:39:63)
      at handle (/home/repos/gotify-to-ntfy-proxy/nodTypeError: undefined is not an object (evaluating 'req.headers.authorization.replace')
```

I think that's because the existing expression is interpreted like that:
```
(req.query.token || req.headers['x-gotify-key'] || req.headers.authorization) ?
    req.headers.authorization.replace('Bearer ', '') : 
    ''
```